### PR TITLE
Convert the ranking system used in the bot to use real ELO

### DIFF
--- a/leaderboard.py
+++ b/leaderboard.py
@@ -1,3 +1,5 @@
+import math
+
 import app
 import pickle
 import statistics
@@ -30,50 +32,19 @@ class LB:
         return new_player
 
 
-def update_scores(score_list):
-    score_data = []
-    elo_data = []
-    lb = get_leaderboard()
+def freaky_regression(player_count: int):
+    if player_count > 4:
+        return 0.547*player_count + 4*math.sqrt(player_count) - 5.7663
+    else:
+        return player_count - 1
+
+
+def update_scores(score_list): # this is gonna suck
 
     for player in score_list:
-        score_data.append(score_list.get(player))
-        lb_player = lb.get_player(player)
-        elo_data.append(lb_player.elo)
 
-    score_data.sort()
-    elo_data.sort()
-
-    mean_score = statistics.mean(score_data)
-    mean_elo = statistics.mean(elo_data)
-
-    if len(score_data) > 2:
-        stdev_score = statistics.stdev(score_data)
-        stdev_elo = statistics.stdev(elo_data)
-    else:
-        stdev_score = max(score_data) - min(score_data)
-        stdev_elo = max(elo_data) - min(elo_data)
 
     leaderboard_msg = "```\nLeaderboard: \n"
-
-    for player in score_list:
-        lb_player = lb.get_player(player)
-        leaderboard_msg += f"{app.get_username_from_id(player)}: {lb_player.elo} -> "
-        elo_add = 0
-        if not stdev_score == 0:
-            elo_add = round((30 * (score_list.get(player) - mean_score) / stdev_score))
-
-        elo_bias = (lb_player.elo - mean_elo)/stdev_elo
-        elo_add -= elo_bias * 10
-
-        lb_player.elo += elo_add
-        if lb_player.elo < 100:
-            lb_player.elo = 100
-        leaderboard_msg += f"{lb_player.elo} "
-        if elo_add < 0:
-            leaderboard_msg += f"({elo_add})\n"
-        else:
-            leaderboard_msg += f"(+{elo_add})\n"
-    add_leaderboard(lb)
 
     leaderboard_msg += "```"
     return leaderboard_msg


### PR DESCRIPTION
Right now, the scores added and subtracted after each fantasy draft game is completely arbitrary and made up based off of z-scores. I'd like to move over to real Elo theory.

Each round played is treated as a round robin. Any player you scored higher than will count as a win and any player you scored lower than will count as a loss. The elo added this way is exorbitantly higher than the elo added in 1v1 chess, for example, so I've stolen awepi's freaky regression originally designed for Glicko in miniTWOWs to this purpose.